### PR TITLE
Get pod namespace from env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ Hazelcast (3.5) cluster discovery mechanism for Kubernetes.
 In order to cluster Hazelcast in Kubernetes - and harness full scale-up/down capabilities provided -, each instance must know beforehand which ```pods``` containing Hazelcast instances are already up & running, so that networking may be configured properly. This is achieved by means of looking-up ```pods``` with certain ```labels``` in [Kubernetes API](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/accessing_the_api.md).
 The code provided does that and configures Hazelcast TCP clustering.
 
+To configure Hazelcast inside of the Kubernetes cluster the following environment options can be used:
+
+* `HAZELCAST_SERVICE` - name of the Hazelcast service, declared in the Kubernetes service configuration. Default: `hazelcast`.
+* `DNS_DOMAIN` - domain name used inside of the cluster. Default: `cluster.local`.
+* `POD_NAMESPACE` - namespace in which hazelcast should be running. Defautl: `default`. Use the [Downward API](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/downward_api.md) to set it automatically.
+* `HC_GROUP_NAME` - Hazelcast group name. Default: `someGroup`.
+* `HC_GROUP_PASSWORD` - Hazelcast group password. Default: `someSecret`.
+* `HC_PORT` - Port on which Hazelcast should be running.
+
 This is used in [pires/hazelcast-kubernetes](https://github.com/pires/hazelcast-kubernetes).
 
 ## Pre-requisites

--- a/src/main/java/com/github/pires/hazelcast/HazelcastDiscoveryController.java
+++ b/src/main/java/com/github/pires/hazelcast/HazelcastDiscoveryController.java
@@ -97,7 +97,8 @@ public class HazelcastDiscoveryController implements CommandLineRunner {
   @Override
   public void run(String... args) {
     final String serviceName = getEnvOrDefault("HAZELCAST_SERVICE", "hazelcast");
-    final String path = "/api/v1/namespaces/default/endpoints/";
+    final String namespace = getEnvOrDefault("POD_NAMESPACE", "default");
+    final String path = String.format("/api/v1/namespaces/%s/endpoints/", namespace);
     final String domain = getEnvOrDefault("DNS_DOMAIN", "cluster.local");
     final String host = getEnvOrDefault("KUBERNETES_MASTER", "https://kubernetes.default.svc.".concat(domain));
     log.info("Asking k8s registry at {}..", host);


### PR DESCRIPTION
With this change it will be possible to run Hazelcast in any namespace (not only default) and automatically check Kubernetes-Hazelcast integration in Kuberentes' E2E tests. Pod namespace will be passed through [downward api](https://github.com/GoogleCloudPlatform/kubernetes/blob/master/docs/downward_api.md).